### PR TITLE
reduce load on SGE with qacct command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+.*
 /src/*.egg-info
 /build
 /dist

--- a/src/toil/batchSystems/abstractGridEngineBatchSystem.py
+++ b/src/toil/batchSystems/abstractGridEngineBatchSystem.py
@@ -416,7 +416,7 @@ class AbstractGridEngineBatchSystem(BatchSystemLocalSupport):
 
     @classmethod
     def getWaitDuration(self):
-        return 1
+        return 15
 
     def sleepSeconds(self, sleeptime=1):
         """ Helper function to drop on all state-querying functions to avoid over-querying.

--- a/src/toil/batchSystems/abstractGridEngineBatchSystem.py
+++ b/src/toil/batchSystems/abstractGridEngineBatchSystem.py
@@ -418,7 +418,7 @@ class AbstractGridEngineBatchSystem(BatchSystemLocalSupport):
     def getWaitDuration(self):
         return 15
 
-    def sleepSeconds(self, sleeptime=15):
+    def sleepSeconds(self, sleeptime=1):
         """ Helper function to drop on all state-querying functions to avoid over-querying.
         """
         time.sleep(sleeptime)

--- a/src/toil/batchSystems/abstractGridEngineBatchSystem.py
+++ b/src/toil/batchSystems/abstractGridEngineBatchSystem.py
@@ -184,7 +184,7 @@ class AbstractGridEngineBatchSystem(BatchSystemLocalSupport):
             while killList:
                 for jobID in list(killList):
                     batchJobID = self.getBatchSystemID(jobID)
-                    if with_retries(self.getJobExitCode, batchJobID) is not None:
+                    if with_retries(self.getJobExitCode, batchJobID, jobID) is not None:
                         logger.debug('Adding jobID %s to killedJobsQueue', jobID)
                         self.killedJobsQueue.put(jobID)
                         killList.remove(jobID)
@@ -207,7 +207,7 @@ class AbstractGridEngineBatchSystem(BatchSystemLocalSupport):
             activity = False
             for jobID in list(self.runningJobs):
                 batchJobID = self.getBatchSystemID(jobID)
-                status = with_retries(self.getJobExitCode, batchJobID)
+                status = with_retries(self.getJobExitCode, batchJobID, jobID)
                 if status is not None:
                     activity = True
                     self.updatedJobsQueue.put((jobID, status))
@@ -285,7 +285,7 @@ class AbstractGridEngineBatchSystem(BatchSystemLocalSupport):
             raise NotImplementedError()
 
         @abstractmethod
-        def getJobExitCode(self, batchJobID):
+        def getJobExitCode(self, batchJobID, jobID):
             """
             Returns job exit code. Implementation-specific; called by
             AbstractGridEngineWorker.checkOnJobs()

--- a/src/toil/batchSystems/abstractGridEngineBatchSystem.py
+++ b/src/toil/batchSystems/abstractGridEngineBatchSystem.py
@@ -418,7 +418,7 @@ class AbstractGridEngineBatchSystem(BatchSystemLocalSupport):
     def getWaitDuration(self):
         return 15
 
-    def sleepSeconds(self, sleeptime=1):
+    def sleepSeconds(self, sleeptime=15):
         """ Helper function to drop on all state-querying functions to avoid over-querying.
         """
         time.sleep(sleeptime)

--- a/src/toil/batchSystems/abstractGridEngineBatchSystem.py
+++ b/src/toil/batchSystems/abstractGridEngineBatchSystem.py
@@ -416,7 +416,7 @@ class AbstractGridEngineBatchSystem(BatchSystemLocalSupport):
 
     @classmethod
     def getWaitDuration(self):
-        return 15
+        return 1
 
     def sleepSeconds(self, sleeptime=1):
         """ Helper function to drop on all state-querying functions to avoid over-querying.

--- a/src/toil/batchSystems/gridengine.py
+++ b/src/toil/batchSystems/gridengine.py
@@ -68,7 +68,7 @@ class GridEngineBatchSystem(AbstractGridEngineBatchSystem):
             result = int(process.stdout.readline().decode('utf-8').strip())
             return result
 
-        def getJobExitCode(self, sgeJobID):
+        def getJobExitCode(self, sgeJobID, jobID):
             # the task is set as part of the job ID if using getBatchSystemID()
             job, task = (sgeJobID, None)
             if '.' in sgeJobID:
@@ -84,9 +84,14 @@ class GridEngineBatchSystem(AbstractGridEngineBatchSystem):
             for line in process.stdout:
                 if line.startswith("failed") and int(line.split()[1]) == 1:
                     return 1
-                elif line.startswith("exit_status"):
+                if line.startswith("jobname") and line.split()[1] == "toil_job_" + jobID:
+                    toil = True
+                if toil and line.startswith("exit_status"):
                     logger.debug('Exit Status: %r', line.split()[1])
                     return int(line.split()[1])
+                #elif line.startswith("exit_status"):
+                #    logger.debug('Exit Status: %r', line.split()[1])
+                #    return int(line.split()[1])
             return None
 
         """

--- a/src/toil/batchSystems/gridengine.py
+++ b/src/toil/batchSystems/gridengine.py
@@ -111,7 +111,6 @@ class GridEngineBatchSystem(AbstractGridEngineBatchSystem):
             sgeArgs = os.getenv('TOIL_GRIDENGINE_ARGS')
             if mem is not None:
                 memStr = str(int(math.ceil(mem/(1024*math.ceil(cpu))))) + 'K'
-                reqline += ['vf=' + memStr, 'h_vmem=' + memStr]
                 # memStr = str(old_div(mem, 1024)) + 'K'
                 if not self.boss.config.manualMemArgs:
                     # for UGE instead of SGE; see #2309

--- a/src/toil/batchSystems/gridengine.py
+++ b/src/toil/batchSystems/gridengine.py
@@ -137,7 +137,7 @@ class GridEngineBatchSystem(AbstractGridEngineBatchSystem):
 
     @classmethod
     def getWaitDuration(cls):
-        return 1
+        return 15
 
     @classmethod
     def obtainSystemConstants(cls):

--- a/src/toil/batchSystems/gridengine.py
+++ b/src/toil/batchSystems/gridengine.py
@@ -110,7 +110,9 @@ class GridEngineBatchSystem(AbstractGridEngineBatchSystem):
             reqline = list()
             sgeArgs = os.getenv('TOIL_GRIDENGINE_ARGS')
             if mem is not None:
-                memStr = str(old_div(mem, 1024)) + 'K'
+                memStr = str(int(math.ceil(mem/(1024*math.ceil(cpu))))) + 'K'
+                reqline += ['vf=' + memStr, 'h_vmem=' + memStr]
+                # memStr = str(old_div(mem, 1024)) + 'K'
                 if not self.boss.config.manualMemArgs:
                     # for UGE instead of SGE; see #2309
                     reqline += ['vf=' + memStr, 'h_vmem=' + memStr]

--- a/src/toil/batchSystems/gridengine.py
+++ b/src/toil/batchSystems/gridengine.py
@@ -80,14 +80,14 @@ class GridEngineBatchSystem(AbstractGridEngineBatchSystem):
                 args.extend(["-t", str(task)])
 
             logger.debug("Running %r", args)
-            toil = False
+            iscurrtoiljob = False
             process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             for line in process.stdout:
                 if line.startswith("failed") and int(line.split()[1]) == 1:
                     return 1
                 if line.startswith("jobname") and line.split()[1] == "toil_job_" + str(jobID):
-                    toil = True
-                if toil and line.startswith("exit_status"):
+                    iscurrtoiljob = True
+                if iscurrtoiljob and line.startswith("exit_status"):
                     logger.debug('Exit Status: %r', line.split()[1])
                     return int(line.split()[1])
                 #elif line.startswith("exit_status"):

--- a/src/toil/batchSystems/gridengine.py
+++ b/src/toil/batchSystems/gridengine.py
@@ -80,11 +80,12 @@ class GridEngineBatchSystem(AbstractGridEngineBatchSystem):
                 args.extend(["-t", str(task)])
 
             logger.debug("Running %r", args)
+            toil = False
             process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             for line in process.stdout:
                 if line.startswith("failed") and int(line.split()[1]) == 1:
                     return 1
-                if line.startswith("jobname") and line.split()[1] == "toil_job_" + jobID:
+                if line.startswith("jobname") and line.split()[1] == "toil_job_" + str(jobID):
                     toil = True
                 if toil and line.startswith("exit_status"):
                     logger.debug('Exit Status: %r', line.split()[1])

--- a/src/toil/batchSystems/lsf.py
+++ b/src/toil/batchSystems/lsf.py
@@ -94,7 +94,7 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
             process = subprocess.Popen(args, stdout=subprocess.PIPE,
                                        stderr=subprocess.STDOUT)
             started = 0
-            for line in process.stdout:
+            for line in process.stdout.readlines():
                 if "Done successfully" in line:
                     logger.debug("bjobs detected job completed for job: "
                                  "{}".format(job))
@@ -132,7 +132,7 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
             args = ["bacct", "-l", str(job)]
             process = subprocess.Popen(args, stdout=subprocess.PIPE,
                                        stderr=subprocess.STDOUT)
-            for line in process.stdout:
+            for line in process.stdout.readlines():
                 if line.find("Completed <done>") > -1:
                     logger.debug("Detected job completed for job: "
                                  "{}".format(job))
@@ -212,7 +212,7 @@ class LSFBatchSystem(AbstractGridEngineBatchSystem):
 
         maxCPU = 0
         maxMEM = MemoryString("0")
-        for line in p.stdout:
+        for line in p.stdout.readlines():
                 items = line.strip().split()
                 if len(items) < num_columns:
                         RuntimeError("lshosts output has a varying number of "


### PR DESCRIPTION
Hi @nikhil 

I opened this PR just as a suggestion

The DMP team had to make a few changes to Toil to get it to work on SGE. The main issue is similar to how we had to do some rate-limiting for LSF

Perhaps @huyu335 can describe these other changes, and we can merge them into a single release of toil-msk that works for both teams

Perhaps you can let me know if there is somewhere else you might suggest we merge this, if you think it's a good idea

Thank you!

